### PR TITLE
Update to 2019-03-14, PaymentMethods, add PaymentMethod.attach for readReusableCard

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     mustermann (1.0.3)
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
-    rack (2.0.6)
+    rack (2.0.7)
     rack-protection (2.0.5)
       rack
     sinatra (2.0.5)
@@ -21,7 +21,7 @@ GEM
       rack-protection (= 2.0.5)
       tilt (~> 2.0)
     sinatra-cross_origin (0.4.0)
-    stripe (4.11.0)
+    stripe (4.12.0)
       faraday (~> 0.13)
       net-http-persistent (~> 3.0)
     tilt (2.0.9)

--- a/web.rb
+++ b/web.rb
@@ -163,11 +163,9 @@ post '/save_payment_method_to_customer' do
 
     payment_method = Stripe::PaymentMethod.construct_from(id: params[:payment_method_id], object: "payment_method")
     payment_method = payment_method.attach(
-      customer: customer.id
+      customer: customer.id,
+      expand: ["customer"]
     )
-
-    customer.refresh
-    payment_methods = Stripe::PaymentMethod.list(customer: customer.id, type: "card", limit: 1, expand: ["data.customer"])
   rescue Stripe::StripeError => e
     status 402
     return log_info("Error attaching PaymentMethod to Customer! #{e.message}")
@@ -176,5 +174,5 @@ post '/save_payment_method_to_customer' do
   log_info("Attached PaymentMethod to Customer: #{customer.id}")
 
   status 200
-  return { customer: customer, payment_methods: payment_methods }.to_json
+  return payment_method.to_json
 end

--- a/web.rb
+++ b/web.rb
@@ -167,7 +167,7 @@ post '/save_payment_method_to_customer' do
     )
 
     customer.refresh
-    payment_methods = Stripe::PaymentMethod.list(customer: customer.id, type: "card")
+    payment_methods = Stripe::PaymentMethod.list(customer: customer.id, type: "card", limit: 1, expand: ["data.customer"])
   rescue Stripe::StripeError => e
     status 402
     return log_info("Error attaching PaymentMethod to Customer! #{e.message}")

--- a/web.rb
+++ b/web.rb
@@ -167,6 +167,7 @@ post '/save_payment_method_to_customer' do
     )
 
     customer.refresh
+    payment_methods = Stripe::PaymentMethod.list(customer: customer.id, type: "card")
   rescue Stripe::StripeError => e
     status 402
     return log_info("Error attaching PaymentMethod to Customer! #{e.message}")
@@ -175,5 +176,5 @@ post '/save_payment_method_to_customer' do
   log_info("Attached PaymentMethod to Customer: #{customer.id}")
 
   status 200
-  return customer.to_json
+  return { customer: customer, payment_methods: payment_methods }.to_json
 end

--- a/web.rb
+++ b/web.rb
@@ -157,7 +157,7 @@ post '/save_card_to_customer' do
   return customer.to_json
 end
 
-post '/save_payment_method_to_customer' do
+post '/attach_payment_method_to_customer' do
   begin
     customer = lookupOrCreateExampleCustomer
 


### PR DESCRIPTION
* Updates the example backend to use the latest API version
* Fixed `PaymentIntent.create` call to use `payment_method_types`
* Updates to latest stripe-ruby, and simplifies the implementation of capture & attach 
using different methods that're available now.
* Adds new endpoint `/attach_payment_method_to_customer` to consume `card` PaymentMethods
from clients.

Fixes #9 