### PR TITLE
Tweak content on API keys and heroku in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ This is a simple [Sinatra](http://www.sinatrarb.com/) webapp that you can use to
 
 1. Set up a free [Heroku account](https://signup.heroku.com). 
 
-2. Connect your Heroku account to GitHub on your Heroku [Account](https://dashboard.heroku.com/account/applications) page.
+2. Obtain your Stripe **secret, test mode** API Key, available in the [Dashboard](https://dashboard.stripe.com/account/apikeys). Note that you must use your secret key, not your publishable key, to set up the backend. For more information on the differences between **secret** and publishable keys, see [API Keys](https://stripe.com/docs/keys). For more information on **test mode**, see [Test and live modes](https://stripe.com/docs/keys#test-live-modes).
 
-3. Obtain your Stripe test secret [API Key](https://stripe.com/docs/keys#api-keys), available in the [Dashboard](https://dashboard.stripe.com/account/apikeys).
-
-4. Click the button below to deploy the example backend. You'll be prompted to enter a name for the Heroku application as well as your Stripe API key.
+3. Click the button below to deploy the example backend. You'll be prompted to enter a name for the Heroku application as well as your Stripe API key.
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 


### PR DESCRIPTION
cc @danj-stripe 

- it's no longer possible to connect your Heroku account to GitHub (this is now done on a per-app basis), so I've removed the step
- I've made it clearer that you need a secret API key, and should use your test mode key.