### PR TITLE
Removes pre-RC1 endpoint: `/save_card_to_customer`

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -131,32 +131,6 @@ def lookupOrCreateExampleCustomer
   end
 end
 
-# This endpoint is used to create a customer and save a card source to it.
-# https://stripe.com/docs/terminal/js/workflows#save-source
-post '/save_card_to_customer' do
-  begin
-    card_source = Stripe::Source.create(
-      :type => "card",
-      :card => {
-        :card_present_source => params[:card_present_source_id],
-      },
-    )
-
-    customer = lookupOrCreateExampleCustomer
-
-    customer.source = card_source.id # obtained with Stripe.js
-    customer.save
-  rescue Stripe::StripeError => e
-    status 402
-    return log_info("Error creating customer with reusable card source! #{e.message}")
-  end
-
-  log_info("Customer created with card source: #{customer.id}")
-
-  status 200
-  return customer.to_json
-end
-
 post '/attach_payment_method_to_customer' do
   begin
     customer = lookupOrCreateExampleCustomer


### PR DESCRIPTION
This was ~replaced with `/attach_payment_method_to_customer` in #8, and now that all of the
client SDKs have been updated & released to use PaymentMethods, this Sources-only endpoint
is unused.

Since we're not (yet?) tagging releases of the example backend, this means anyone who
deploys this project & tries to use it from an older beta of the clients will be broken,
but there shouldn't be any/many people doing that.