### PR TITLE
Add error when configured with incorrect key

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -37,6 +37,9 @@ get '/' do
 end
 
 def validateApiKey
+  if Stripe.api_key.nil? || Stripe.api_key.empty?
+    return "Error: you provided an empty secret key. Please provide your test mode secret key. For more information, see https://stripe.com/docs/keys"
+  end
   if Stripe.api_key.start_with?('pk')
     return "Error: you used a publishable key to set up the example backend. Please use your test mode secret key. For more information, see https://stripe.com/docs/keys"
   end


### PR DESCRIPTION
r? @danj-stripe 

```
⟩ curl -X POST http://localhost:5000/connection_token -d ''
Error: you used a publishable key to set up the example backend. Please use your test mode secret key. For more information, see https://stripe.com/docs/keys

⟩ curl -X POST http://localhost:5000/connection_token -d ''
Error: you used a live mode secret key to set up the example backend. Please use your test mode secret key. For more information, see https://stripe.com/docs/keys#test-live-modes
```