### PR TITLE
let frontend control payment_method_types

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -113,7 +113,7 @@ post '/create_payment_intent' do
 
   begin
     payment_intent = Stripe::PaymentIntent.create(
-      :payment_method_types => ['card_present'],
+      :payment_method_types => params[:payment_method_types] || ['card_present'],
       :capture_method => 'manual',
       :amount => params[:amount],
       :currency => params[:currency] || 'usd',


### PR DESCRIPTION
this value could be `['card_present']` or `['card_present', 'interac_present']` depends on whether the transaction is in CA. The frontend should control this logic, which is similar to how `createPaymentIntent` API is structured