### PR TITLE
forward payment method options if given

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -119,6 +119,7 @@ post '/create_payment_intent' do
       :amount => params[:amount],
       :currency => params[:currency] || 'usd',
       :description => params[:description] || 'Example PaymentIntent',
+      :payment_method_options => params[:payment_method_options] || [],
     )
   rescue Stripe::StripeError => e
     status 402


### PR DESCRIPTION
Send the `params[:payment_method_options]` to stripe's api if they are given

## Testing
Tested with extended_auth and a simulated WPE on the external iOS example app 
Test sending a blank array to `:payment_method_options` to ensure this does not break anything