### PR TITLE
Add optional param capture_method on /capture_payment_intent

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -115,7 +115,7 @@ post '/create_payment_intent' do
   begin
     payment_intent = Stripe::PaymentIntent.create(
       :payment_method_types => params[:payment_method_types] || ['card_present'],
-      :capture_method => 'manual',
+      :capture_method => params[:capture_method] || 'manual',
       :amount => params[:amount],
       :currency => params[:currency] || 'usd',
       :description => params[:description] || 'Example PaymentIntent',


### PR DESCRIPTION
Add optional capture_method param in  '/capture_payment_intent' POST endpoint.