### PR TITLE
Add deploy to render button to readme and render.yaml to support that

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a simple [Sinatra](http://www.sinatrarb.com/) webapp that you can use to
 ### Running on Render
 
 1. Set up a free [render account](https://dashboard.render.com/register).
-2. Click the button below to deploy the example backend. You'll be prompted to enter a name for the Render application as well as your Stripe API key.
+2. Click the button below to deploy the example backend. You'll be prompted to enter a name for the Render service group as well as your Stripe API key.
 3. Go to the [next steps](#next-steps) in this README for how to use this app
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/stripe/example-terminal-backend/)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 This is a simple [Sinatra](http://www.sinatrarb.com/) webapp that you can use to run the [Stripe Terminal](https://stripe.com/docs/terminal) example apps. To get started, you can choose from the following options:
 
 1. [Run it on a free Render account](#running-on-render)
-2. [Run it locally on your machine](#running-locally-on-your-machine)
-3. [Run it locally via Docker CLI](#running-locally-with-docker)
+2. [Run it on Heroku](#running-on-heroku)
+3. [Run it locally on your machine](#running-locally-on-your-machine)
+4. [Run it locally via Docker CLI](#running-locally-with-docker)
 
 ℹ️  You also need to obtain your Stripe **secret, test mode** API Key, available in the [Dashboard](https://dashboard.stripe.com/account/apikeys). Note that you must use your secret key, not your publishable key, to set up the backend. For more information on the differences between **secret** and publishable keys, see [API Keys](https://stripe.com/docs/keys). For more information on **test mode**, see [Test and live modes](https://stripe.com/docs/keys#test-live-modes).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a simple [Sinatra](http://www.sinatrarb.com/) webapp that you can use to run the [Stripe Terminal](https://stripe.com/docs/terminal) example apps. To get started, you can choose from the following options:
 
-1. [Run it on a free Heroku account](#running-on-heroku)
+1. [Run it on a free Render account](#running-on-render)
 2. [Run it locally on your machine](#running-locally-on-your-machine)
 3. [Run it locally via Docker CLI](#running-locally-with-docker)
 
@@ -10,9 +10,17 @@ This is a simple [Sinatra](http://www.sinatrarb.com/) webapp that you can use to
 
 ## Running the app
 
+### Running on Render
+
+1. Set up a free [render account](https://dashboard.render.com/register).
+2. Click the button below to deploy the example backend. You'll be prompted to enter a name for the Render application as well as your Stripe API key.
+3. Go to the [next steps](#next-steps) in this README for how to use this app
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/stripe/example-terminal-backend/)
+
 ### Running on Heroku
 
-1. Set up a free [Heroku account](https://signup.heroku.com).
+1. Set up a [Heroku account](https://signup.heroku.com).
 2. Click the button below to deploy the example backend. You'll be prompted to enter a name for the Heroku application as well as your Stripe API key.
 3. Go to the [next steps](#next-steps) in this README for how to use this app
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: example-terminal-backend
+    env: ruby
+    region: oregon
+    plan: free
+    buildCommand: bundle install
+    startCommand: bundle exec ruby web.rb
+    envVars:
+      - key: STRIPE_TEST_SECRET_KEY
+        sync: false # placeholder for a value to be added in the dashboard
+

--- a/render.yaml
+++ b/render.yaml
@@ -9,4 +9,3 @@ services:
     envVars:
       - key: STRIPE_TEST_SECRET_KEY
         sync: false # placeholder for a value to be added in the dashboard
-


### PR DESCRIPTION
Add render.yaml and "Deploy to Render" button to the readme as an alternative to heroku.

Should we remove the heroku lines? 🤔 🤷‍♂️ I'm leaving them for now since it still works but I don't feel strongly here.

## Test plan

* previous commit had this branch appended to the URL in the button. Pressed that and saw it offer the env var to fill in and all. Deployed and saw it work 🎉 
* used it with the react native sample app to e2e test it. No issues.
* billfinn-stripe tested the deploy link as well while pointed to this branch