### PR TITLE
Allow to use production keys

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -43,7 +43,7 @@ def validateApiKey
   if Stripe.api_key.start_with?('pk')
     return "Error: you used a publishable key to set up the example backend. Please use your test mode secret key. For more information, see https://stripe.com/docs/keys"
   end
-  if Stripe.api_key.start_with?('sk_live')
+  if Stripe.api_key.start_with?('sk_live') && ENV['STRIPE_ENV'] != 'production'
     return "Error: you used a live mode secret key to set up the example backend. Please use your test mode secret key. For more information, see https://stripe.com/docs/keys#test-live-modes"
   end
   return nil


### PR DESCRIPTION
This example app already provides a way to use a production secret key by setting `STRIPE_ENV` variable to `production`. So key validation should allow for that as well.