### PR TITLE
add amount to capture param in capture payment intent call

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -145,7 +145,11 @@ end
 post '/capture_payment_intent' do
   begin
     id = params["payment_intent_id"]
-    payment_intent = Stripe::PaymentIntent.capture(id)
+    if !params[:amount_to_capture].nil?
+      payment_intent = Stripe::PaymentIntent.capture(id, params = {:amount_to_capture => params[:amount_to_capture]})
+    else
+      payment_intent = Stripe::PaymentIntent.capture(id)
+    end
   rescue Stripe::StripeError => e
     status 402
     return log_info("Error capturing PaymentIntent! #{e.message}")


### PR DESCRIPTION
Adds `amount_to_capture` param for the Capture Payment Intent endpoint. 